### PR TITLE
Update recurring_tasks.rst

### DIFF
--- a/content/applications/services/project/tasks/recurring_tasks.rst
+++ b/content/applications/services/project/tasks/recurring_tasks.rst
@@ -18,7 +18,7 @@ activate :guilabel:`Recurring Tasks`, and press :guilabel:`Save`.
 Set up task recurrence
 ----------------------
 
-In an existing task, press the :guilabel:`Recurrent` button next to the :guilabel:`Planned date`.
+In an existing task, press the :guilabel:`Recurrent` button "Please add the image of the recuurent button" next to the :guilabel:`Planned date`.
 Then, configure :guilabel:`Repeat Every` field according to your needs.
 
 A new task in recurrence will be created once either of this conditions is met:


### PR DESCRIPTION
Dear Odoo Team,

Upon reviewing the documentation for recurring tasks in the Project Management module, I noticed that the button image is missing. Including this image would significantly benefit users and make the documentation clearer.

I have attached the actual button image along with a reference for your convenience. Kindly review and consider adding it to the documentation.

You can view the documentation here: https://www.odoo.com/documentation/18.0/applications/services/project/tasks/recurring_tasks.html

And here’s the link to the images: 
https://drive.google.com/drive/folders/11T3z9NVZ0lbGG-LvW3YPiMFsT8daA6PY?usp=sharing